### PR TITLE
Fix the SATP change bug on CVA6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CROSSCOMPILE = $(shell which riscv${KEYSTONE_BITS}-buildroot-linux-gnu-gcc | rev | cut -c 4- | rev)
+CROSSCOMPILE ?= $(shell which riscv${KEYSTONE_BITS}-buildroot-linux-gnu-gcc | rev | cut -c 4- | rev)
 CC = $(CROSSCOMPILE)gcc
 OBJCOPY = $(CROSSCOMPILE)objcopy
 

--- a/build.sh
+++ b/build.sh
@@ -4,5 +4,5 @@ LOADER_SOURCE_DIR=`dirname $0`
 BITS="64"
 
 export BITS
-make -C $LOADER_SOURCE_DIR clean
-make -C $LOADER_SOURCE_DIR
+make -C $LOADER_SOURCE_DIR $* clean
+make -C $LOADER_SOURCE_DIR $*

--- a/loader.S
+++ b/loader.S
@@ -58,7 +58,14 @@ _start:
   csrw stvec, t0  // store runtime start addresss in stvec 
 
   la a0, root_page_table  
-  call satp_new // construct new satp
+  li a1, 12
+  li a2, SATP_MODE
+  srl a0, a0, a1
+  or a0, a0, a2
+
+  // Flush TLB's just in case:
+  fence.i
+  sfence.vma
 
   // set arguments for eyrie_boot
   LOAD a1, 0(sp)
@@ -69,7 +76,10 @@ _start:
   LOAD a6, 5*REGBYTES(sp)
   LOAD a7, 6*REGBYTES(sp)
 
+  // Flush TLB's just in case:
+  fence.i
   sfence.vma
+
   csrw satp, a0 // switch to virtual addresssing 
   sfence.vma
 

--- a/loader.c
+++ b/loader.c
@@ -152,13 +152,6 @@ int loadElf(elf_t* elf) {
    return 0; //TODO: error class later
 }
 
-/* Loader is for Sv39 */
-uintptr_t satp_new(uintptr_t pa)
-{
-  printf("Create new satp\n");
-  return (SATP_MODE | (pa >> RISCV_PAGE_BITS));
-}
-
 void
 map_physical_memory(uintptr_t dram_base,
                     uintptr_t dram_size)


### PR DESCRIPTION
Retain backwards compatibility to the old build system by allowing to set CROSSCOMPILE from command-line:

```bash
./build.sh CROSSCOMPILE=riscv64-unknown-linux-gnu-
```

Link: https://www.gnu.org/software/make/manual/html_node/Setting.html